### PR TITLE
Avoid segfault by adding client code to opcache blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install PHP extensions required by php-zerorpc on CentOS servers:
 Requirements
 ------------
 
-Written in Ansible 1.9.*
+Written in Ansible 2.3.*
 
 Please make sure PHP pecl command installed.
 
@@ -17,6 +17,12 @@ Role Variables
 --------------
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+### msgpack_source_version
+
+Commit, tag, or branch of msgpack PHP extension to use when installing from source.
+
+Default is `msgpack-2.0.2`.
 
 ### pecl_msgpack_version
 
@@ -30,11 +36,35 @@ ZeroMQ PHP extension version.
 
 Default is `1.1.2`.
 
+### php_extensions_config_path
+
+Path of folder containing PHP extension config files.
+
+Default is `/etc/php.d`.
+
 ### php_fpm_daemon
 
 php_fpm daemon's name.
 
 Default is `php-fpm`.
+
+### php_opcache_config_filename
+
+PHP opcache extension config filename.
+
+Default is `10-opcache.ini`.
+
+### php_zerorpc_segfault_fix
+
+Enable to avoid segfault in PHP7 with opcache.
+
+Default is `false`.
+
+### zmq_source_version
+
+Commit, tag, or branch of zmq PHP extension to use when installing from source.
+
+Default is `f2617063a4c007ca6073c0d09e9f36fd9b87ddaf`.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,16 @@
 ---
 msgpack_source_version: 'msgpack-2.0.2'
-pecl_msgpack_version: 0.5.7
-pecl_zmq_version: 1.1.2
 
-php_fpm_daemon: php-fpm
+pecl_msgpack_version: '0.5.7'
+pecl_zmq_version: '1.1.2'
+
+php_extensions_config_path: '/etc/php.d'
+php_fpm_daemon: 'php-fpm'
+php_opcache_config_filename: '10-opcache.ini'
+
+# Enable this to avoid the segfault that happens in the zerorpc php client
+# when running php7 with opcache
+php_zerorpc_segfault_fix: false
 
 # zmq version 1.1.3
 zmq_source_version: 'f2617063a4c007ca6073c0d09e9f36fd9b87ddaf'

--- a/files/opcache-zerorpc.blacklist
+++ b/files/opcache-zerorpc.blacklist
@@ -1,0 +1,1 @@
+/**/zerorpc-php/src/Client.php

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,10 +45,10 @@
     chdir: /tmp/php-msgpack
   when: "'PHP 7' in php_version.stdout"
 
-- name: ensure zmq and msgpack extension present in php.d/*.ini
+- name: ensure zmq and msgpack extension present in php config
   template:
     src: package.ini.j2
-    dest: "/etc/php.d/{{ item }}.ini"
+    dest: '/{{ php_extensions_config_path }}/{{ item }}.ini'
   with_items:
     - zmq
     - msgpack

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,3 +53,16 @@
     - zmq
     - msgpack
   notify: restart php-fpm
+
+- name: create opcache blacklist file (fix segfault)
+  copy:
+    src: 'files/opcache-zerorpc.blacklist'
+    dest: '{{ php_extensions_config_path }}/opcache-zerorpc.blacklist'
+  when: php_zerorpc_segfault_fix
+
+- name: add opcache blacklist file to config (fix segfault)
+  lineinfile:
+    dest: '{{ php_extensions_config_path }}/{{ php_opcache_config_filename }}'
+    line: 'opcache.blacklist_filename={{ php_extensions_config_path }}/opcache*.blacklist'
+    regexp: 'opcache.blacklist_filename'
+  when: php_zerorpc_segfault_fix

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+test.retry

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+system("ansible-galaxy install -f -i -p roles -r requirements.yml")
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "juwai-centos68"
+  config.vm.box_url = "http://downloads.juwai.io/devops/boxes/juwai-centos68.box"
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "test.yml"
+  end
+end

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,7 +1,11 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-system("ansible-galaxy install -f -i -p roles -r requirements.yml")
+system("
+    if [ #{ARGV[0]} = 'up' ]; then
+        ansible-galaxy install -f -i -p roles -r requirements.yml
+    fi
+")
 
 Vagrant.configure(2) do |config|
   config.vm.box = "juwai-centos68"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,2 @@
+---
+- src: juwai.libzmq

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,2 +1,3 @@
 ---
 - src: juwai.libzmq
+- src: geerlingguy.php

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- hosts: default
+  remote_user: vagrant
+  become: yes
+  roles:
+    - php-zerorpc

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,11 @@
 ---
 - hosts: default
-  remote_user: vagrant
+  remote_user: 'vagrant'
   become: yes
+  vars:
+    php_webserver_daemon: 'php-fpm'
+    php_packages:
+      - 'php-fpm'
   roles:
-    - php-zerorpc
+    - 'geerlingguy.php'
+    - 'php-zerorpc'


### PR DESCRIPTION
## Summary of changes

- Add two tasks to set zerorpc client code in opcache blacklist
- Create test playbook
- Update readme

## How to Test

1. Go to `tests/` folder
2. Run: `$ vagrant up`
3. See playbook run without errors

(This only tests that the role doesn't break. To test the new tasks you need to install PHP with opcache.)

## Notes

The segfault happens randomly when Client.php is cached and used to call a remote function. If `opcache.protect_memory` is enabled, it happens consistently. Here is a core dump:

```
#0  i_zval_ptr_dtor (zval_ptr=0x7f822bded008) at /usr/src/debug/php-7.1.11/Zend/zend_variables.h:46
#1  _zval_ptr_dtor (zval_ptr=0x7f822bded008) at /usr/src/debug/php-7.1.11/Zend/zend_execute_API.c:550
#2  0x00000000005fc155 in zend_hash_clean (ht=0x7f822e7c5090) at /usr/src/debug/php-7.1.11/Zend/zend_hash.c:1348
#3  0x00007f82322b689a in php_zmq_pollset_poll (set=0x7f822a40c2c0, timeout=<value optimized out>, r_array=0x7f823f66e9f8, w_array=0x7f823f66eda0) at /tmp/php-zmq/zmq_pollset.c:312
#4  0x00007f82322b3bb0 in zim_zmqpoll_poll (execute_data=<value optimized out>, return_value=0x7f823f6158e0) at /tmp/php-zmq/zmq.c:1440
#5  0x0000000000668025 in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER (execute_data=0x7f823f615800) at /usr/src/debug/php-7.1.11/Zend/zend_vm_execute.h:1097
#6  0x0000000000646f28 in execute_ex (ex=<value optimized out>) at /usr/src/debug/php-7.1.11/Zend/zend_vm_execute.h:432
#7  0x00000000005dd730 in zend_call_function (fci=0x7ffd4c7dbda0, fci_cache=0x7ffd4c7dbde0) at /usr/src/debug/php-7.1.11/Zend/zend_execute_API.c:855
#8  0x000000000052a14c in zif_call_user_func_array (execute_data=0x7f823f615620, return_value=0x7f823f615600) at /usr/src/debug/php-7.1.11/ext/standard/basic_functions.c:4860
#9  0x00000000006672f7 in ZEND_DO_FCALL_BY_NAME_SPEC_RETVAL_USED_HANDLER (execute_data=0x7f823f615590) at /usr/src/debug/php-7.1.11/Zend/zend_vm_execute.h:876
#10 0x0000000000646f28 in execute_ex (ex=<value optimized out>) at /usr/src/debug/php-7.1.11/Zend/zend_vm_execute.h:432
#11 0x0000000000692d30 in zend_execute (op_array=0x7f823f66f000, return_value=<value optimized out>) at /usr/src/debug/php-7.1.11/Zend/zend_vm_execute.h:474
#12 0x00000000005eb2c3 in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /usr/src/debug/php-7.1.11/Zend/zend.c:1482
#13 0x0000000000589a80 in php_execute_script (primary_file=0x7ffd4c7de4d0) at /usr/src/debug/php-7.1.11/main/main.c:2577
#14 0x000000000069fdee in main (argc=<value optimized out>, argv=<value optimized out>) at /usr/src/debug/php-7.1.11/sapi/fpm/fpm/fpm_main.c:1966
```