### PR TITLE
Update opcache blacklist file

### DIFF
--- a/files/opcache-zerorpc.blacklist
+++ b/files/opcache-zerorpc.blacklist
@@ -1,1 +1,1 @@
-/**/zerorpc-php/src/Client.php
+/**/zerorpc-php/src/*


### PR DESCRIPTION
## Summary of changes

Don't add any of the zerorpc package files in opcache. I initially thought only the Client file would cause segfaults, but turns out the Channel file also will. The channel file is used when dispatching asynchronous requests. To be safe, let's skip the whole package.

## How to Test

Run a playbook that includes this role and has `php_zerorpc_segfault_fix: true`.